### PR TITLE
fallback to git command when the commit-action failed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,24 @@ runs:
       repository: ${{ inputs.destination-repository }}
       commit_message: ${{ steps.prepare.outputs.commit-message }}
       branch: ${{ inputs.destination-branch }}
+    continue-on-error: true
+  - name: fallback to git command for large assets
+    if: failure()
+    run: |
+      set -euo pipefail
+      git config user.name "${GITHUB_ACTOR}"
+      git config user.email "${GITHUB_ACTOR}"@users.noreply.github.com
+      repo="https://$GITHUB_ACTOR:$GITHUB_TOKEN@$github.com/${DESTINATION_REPOSITORY}.git"
+      git add .
+      git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
+      git push $repo --set-upstream "$DESTINATION_BRANCH"
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      COMMIT_MESSAGE: ${{ steps.prepare.outputs.commit-message }}
+      DESTINATION_BRANCH: ${{ inputs.destination-branch }}
+      DESTINATION_REPOSITORY: ${{ inputs.destination-repository }}
+    continue-on-error: true
+    shell: bash
   - name: restore stashed original workspace from worktree
     run: |
       TEMP_DIR="$(mktemp -d)/$WORKTREE_DIR"
@@ -70,6 +88,7 @@ runs:
       rm -rf "$GITHUB_WORKSPACE"
       mv "$TEMP_DIR" "$GITHUB_WORKSPACE"
     shell: bash
+    if: always()
     env:
       WORKTREE_DIR: .push-to-another-repository
 branding:


### PR DESCRIPTION
It seems GitHub's API cannot accept files larger than 50MB (or 37.5MB for binary files) for put operations.