### PR TITLE
Revert "refactor: simplify workspace handling"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
       persist-credentials: false
       path: .push-to-another-repository
   - id: prepare
-    name: "Prepare the destination repository in the worktree before committing"
+    name: "Prepare the destination repository in the workspace before committing"
     run: $GITHUB_ACTION_PATH/entrypoint.sh
     shell: bash
     env:
@@ -63,7 +63,6 @@ runs:
       repository: ${{ inputs.destination-repository }}
       commit_message: ${{ steps.prepare.outputs.commit-message }}
       branch: ${{ inputs.destination-branch }}
-    working-directory: .push-to-another-repository
     continue-on-error: true
   - id: fallback
     name: fallback to git command for large assets
@@ -82,12 +81,14 @@ runs:
       COMMIT_MESSAGE: ${{ steps.prepare.outputs.commit-message }}
       DESTINATION_BRANCH: ${{ inputs.destination-branch }}
       DESTINATION_REPOSITORY: ${{ inputs.destination-repository }}
-    working-directory: .push-to-another-repository
     continue-on-error: true
     shell: bash
-  - name: remove worktree
+  - name: restore stashed original workspace from worktree
     run: |
-      rm -rf "$WORKTREE_DIR"
+      TEMP_DIR="$(mktemp -d)/$WORKTREE_DIR"
+      mv ./$WORKTREE_DIR "$TEMP_DIR"
+      rm -rf "$GITHUB_WORKSPACE"
+      mv "$TEMP_DIR" "$GITHUB_WORKSPACE"
     shell: bash
     if: always()
     env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,18 +24,13 @@ mkdir -p "$ABSOLUTE_DESTINATION_DIRECTORY"
 
 mv "$TEMP_WORKDIR/.git" "$CLONE_DIR/.git"
 
-echo "[+] Evacuating source .git directory to avoid conflicts when mirroring the root directory"
-mv "./.git" "$TEMP_WORKDIR/.git"
+echo "[+] evacuate source .git directory to avoid conflicts when mirroring the root directory"
+mv "$GITHUB_WORKSPACE/.git" "$TEMP_WORKDIR/.git"
 
 echo "[+] Copying contents of source repository folder $SOURCE_DIRECTORY to folder $DESTINATION_DIRECTORY in destination repository"
 cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$DESTINATION_DIRECTORY"
 
-echo "[+] Restoring source .git directory"
-mv "$TEMP_WORKDIR/.git" "./.git"
-
-echo "[+] Moving cloned repository to $WORKTREE_DIR in the workspace"
-mv "$CLONE_DIR" "./$WORKTREE_DIR"
-
+cd "$CLONE_DIR"
 echo "[+] Building commit message"
 COMMIT_MESSAGE="${COMMIT_MESSAGE/LAST_COMMIT_MESSAGE/$LAST_COMMIT_MESSAGE}"
 ORIGIN_COMMIT="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
@@ -46,3 +41,14 @@ COMMIT_MESSAGE="${COMMIT_MESSAGE/GITHUB_REF/$GITHUB_REF}"
   echo "$COMMIT_MESSAGE"
   echo 'EOF'
 } >> "$GITHUB_OUTPUT"
+
+echo "[+] Swap github.workspace with the cloned repository to work with commit-action"
+mv "$GITHUB_WORKSPACE" "$TEMP_WORKDIR/$WORKTREE_DIR"
+mv "$TEMP_WORKDIR/.git" "$TEMP_WORKDIR/$WORKTREE_DIR/.git"
+mv "$CLONE_DIR" "$GITHUB_WORKSPACE"
+
+# Stash the original workspace in a ignored worktree directory.
+mv "$TEMP_WORKDIR/$WORKTREE_DIR" "$GITHUB_WORKSPACE/$WORKTREE_DIR"
+cd "$GITHUB_WORKSPACE"
+# The stash directory is ignored from version control.
+echo "$WORKTREE_DIR" >> .git/info/exclude


### PR DESCRIPTION
Reverts Songmu/action-push-to-another-repository#41

Custom actions can't accept `working-directory`.